### PR TITLE
support local and UTC date-time

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -516,7 +516,7 @@ func parseDate(prop *Property) (time.Time, error) {
 	}
 
 	if len(prop.Value) == 15 {
-		return time.Parse(dateTimeLayoutLocalized, prop.Value)
+		return time.ParseInLocation(dateTimeLayoutLocalized, prop.Value, time.Local)
 	}
 
 	if val, ok := prop.Params["VALUE"]; ok {

--- a/parse_test.go
+++ b/parse_test.go
@@ -38,14 +38,36 @@ var dateList = []*Property{
 		},
 		Value: "19980119T020000",
 	},
+	// Floating (local) date-time (no time zone)
+	&Property{
+		Name: "DSTART",
+		Params: map[string]*Param{
+			"VALUE": &Param{
+				Values: []string{"DATE"},
+			},
+		},
+		Value: "19980119T020000",
+	},
+	// Date-time in UTC
+	&Property{
+		Name: "DSTART",
+		Params: map[string]*Param{
+			"VALUE": &Param{
+				Values: []string{"DATE"},
+			},
+		},
+		Value: "19980119T070000Z",
+	},
 }
 
 func TestParseDate(t *testing.T) {
 	for _, prop := range dateList {
-		_, err := parseDate(prop)
+		out, err := parseDate(prop)
 
 		if err != nil {
 			t.Error(err)
+		} else {
+			t.Logf("in: %+v, out: %s", prop.Value, out)
 		}
 	}
 }


### PR DESCRIPTION
Adds support for local and UTC date-time in DTSTART that do not have a TZID.
Formats that now work: `19980119T020000` and `19980119T070000Z`