### PR TITLE
Fix bad tzid value

### DIFF
--- a/fixtures/example.ics
+++ b/fixtures/example.ics
@@ -9,8 +9,8 @@ DTSTART:19960918T143000Z
 DTEND:19960920T220000Z
 STATUS:CONFIRMED
 CATEGORIES:CONFERENCE
-SUMMARY:Networld+Interop Conference
-DESCRIPTION:Networld+Interop Conference and Exhibit\nAtlanta World Congress Center\n Atlanta\, Georgia
+SUMMARY;FOO=bar,"baz":Networld+Interop Conference
+DESCRIPTION;ALTREP="cid:part1.0001@example.org":Networld+Interop Conference and Exhibit\nAtlanta World Congress Center\n Atlanta\, Georgia
 END:VEVENT
 BEGIN:VEVENT
 DTSTAMP:19960704T120000Z

--- a/parse.go
+++ b/parse.go
@@ -519,7 +519,13 @@ func parseDate(prop *Property, l *time.Location) (time.Time, error) {
 	}
 
 	if tz, ok := prop.Params["TZID"]; ok {
-		loc, _ := time.LoadLocation(tz.Values[0])
+		loc, err := time.LoadLocation(tz.Values[0])
+
+		// In case we are not able to load TZID location we default to UTC
+		if err != nil {
+			loc = time.UTC
+		}
+
 		return time.ParseInLocation(dateTimeLayoutLocalized, prop.Value, loc)
 	}
 

--- a/parse_test.go
+++ b/parse_test.go
@@ -102,6 +102,22 @@ func Test_parseDate(t *testing.T) {
 			},
 			want: time.Date(1998, time.January, 19, 7, 0, 0, 0, time.Local),
 		},
+		{
+			name: "Datetime with bad timezone",
+			args: args{
+				prop: &Property{
+					Name: "DTSTART",
+					Params: map[string]*Param{
+						"TZID": &Param{
+							Values: []string{"Z"},
+						},
+					},
+					Value: "19980119T020000",
+				},
+				l: time.Local,
+			},
+			want: time.Date(1998, time.January, 19, 2, 0, 0, 0, time.UTC),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
fixes #3 

If there is a bad value for the param `TZID`, date parsing defaults now to `UTC`.